### PR TITLE
[Refact] config를 통한 설정 파일 받기

### DIFF
--- a/.github/workflows/deploy-ku-cd.yml
+++ b/.github/workflows/deploy-ku-cd.yml
@@ -33,7 +33,7 @@ jobs:
           GOOGLE_SECRET: ${{ secrets.GOOGLE_SECRET }}
           KAKAO_ID: ${{ secrets.KAKAO_ID }}
           KAKAO_SECRET: ${{ secrets.KAKAO_SECRET }}
-        run: /gradlew build -Pprofile=prod
+        run: ./gradlew build -Dspring.profiles.active=prod
 
         # dockerfile을 통해 이미지를 빌드하고, 이를 docker repo로 push
       - name: Docker build & push to docker repo

--- a/.github/workflows/deploy-ku-cd.yml
+++ b/.github/workflows/deploy-ku-cd.yml
@@ -33,7 +33,7 @@ jobs:
           GOOGLE_SECRET: ${{ secrets.GOOGLE_SECRET }}
           KAKAO_ID: ${{ secrets.KAKAO_ID }}
           KAKAO_SECRET: ${{ secrets.KAKAO_SECRET }}
-        run: ./gradlew build -Dspring.profiles.active=prod
+        run: ./gradlew build
 
         # dockerfile을 통해 이미지를 빌드하고, 이를 docker repo로 push
       - name: Docker build & push to docker repo

--- a/.github/workflows/deploy-ku-cd.yml
+++ b/.github/workflows/deploy-ku-cd.yml
@@ -33,7 +33,7 @@ jobs:
           GOOGLE_SECRET: ${{ secrets.GOOGLE_SECRET }}
           KAKAO_ID: ${{ secrets.KAKAO_ID }}
           KAKAO_SECRET: ${{ secrets.KAKAO_SECRET }}
-        run: ./gradlew build
+        run: /gradlew build -Pprofile=prod
 
         # dockerfile을 통해 이미지를 빌드하고, 이를 docker repo로 push
       - name: Docker build & push to docker repo

--- a/.github/workflows/deploy-ku-ci.yml
+++ b/.github/workflows/deploy-ku-ci.yml
@@ -34,6 +34,14 @@ jobs:
           KAKAO_SECRET: ${{ secrets.KAKAO_SECRET }}
         run: ./gradlew build -Dspring.profiles.active=local
 
+      - name: Test with Gradle
+        env:
+          GOOGLE_ID: ${{ secrets.GOOGLE_ID }}
+          GOOGLE_SECRET: ${{ secrets.GOOGLE_SECRET }}
+          KAKAO_ID: ${{ secrets.KAKAO_ID }}
+          KAKAO_SECRET: ${{ secrets.KAKAO_SECRET }}
+        run: ./gradlew test -Dspring.profiles.active=local
+
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/deploy-ku-ci.yml
+++ b/.github/workflows/deploy-ku-ci.yml
@@ -32,7 +32,7 @@ jobs:
           GOOGLE_SECRET: ${{ secrets.GOOGLE_SECRET }}
           KAKAO_ID: ${{ secrets.KAKAO_ID }}
           KAKAO_SECRET: ${{ secrets.KAKAO_SECRET }}
-        run: /gradlew build -Pprofile=local
+        run: ./gradlew build -Dspring.profiles.active=local
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/deploy-ku-ci.yml
+++ b/.github/workflows/deploy-ku-ci.yml
@@ -32,7 +32,7 @@ jobs:
           GOOGLE_SECRET: ${{ secrets.GOOGLE_SECRET }}
           KAKAO_ID: ${{ secrets.KAKAO_ID }}
           KAKAO_SECRET: ${{ secrets.KAKAO_SECRET }}
-        run: ./gradlew build
+        run: ./gradlew test
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/deploy-ku-ci.yml
+++ b/.github/workflows/deploy-ku-ci.yml
@@ -32,7 +32,7 @@ jobs:
           GOOGLE_SECRET: ${{ secrets.GOOGLE_SECRET }}
           KAKAO_ID: ${{ secrets.KAKAO_ID }}
           KAKAO_SECRET: ${{ secrets.KAKAO_SECRET }}
-        run: ./gradlew build -Dspring.profiles.active=local
+        run: ./gradlew build
 
       - name: Test with Gradle
         env:
@@ -40,7 +40,7 @@ jobs:
           GOOGLE_SECRET: ${{ secrets.GOOGLE_SECRET }}
           KAKAO_ID: ${{ secrets.KAKAO_ID }}
           KAKAO_SECRET: ${{ secrets.KAKAO_SECRET }}
-        run: ./gradlew test -Dspring.profiles.active=local
+        run: ./gradlew test
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/deploy-ku-ci.yml
+++ b/.github/workflows/deploy-ku-ci.yml
@@ -32,7 +32,7 @@ jobs:
           GOOGLE_SECRET: ${{ secrets.GOOGLE_SECRET }}
           KAKAO_ID: ${{ secrets.KAKAO_ID }}
           KAKAO_SECRET: ${{ secrets.KAKAO_SECRET }}
-        run: ./gradlew test
+        run: /gradlew build -Pprofile=local
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -18,4 +18,4 @@ ENV KAKAO_ID=${KAKAO_ID}
 ENV KAKAO_SECRET=${KAKAO_SECRET}
 
 # 운영 및 개발에서 사용되는 환경 설정을 분리
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+ENTRYPOINT ["java", "-jar", "/app.jar","--spring.profiles.active=local"]

--- a/infra/docker/secret.yml
+++ b/infra/docker/secret.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: user-service-secrets
+type: Opaque
+#data:
+#  GOOGLE_ID:
+#  GOOGLE_SECRET:
+#  KAKAO_ID:
+#  KAKAO_SECRET:
+#  SECRET:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,15 +62,12 @@ spring:
     config:
       enabled: false  # 로컬 환경에서 Config 서버 비활성화
 
-server:
-  port: 8000
-
 eureka:
   client:
-    register-with-eureka: true
-    fetch-registry: true
-    service-url:
-      defaultZone: http://localhost:8761/eureka  # 로컬에서의 eureka 설정
+    enabled: false  # 로컬 환경에서 Eureka 클라이언트 비활성화
+
+server:
+  port: 8000
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,18 +1,25 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+
 server:
   port: 8000
+
 eureka:
   client:
     register-with-eureka: true
     fetch-registry: true
     service-url:
-      defaultZone: http://172.31.13.241:8761/eureka
+      defaultZone: http://localhost:8761/eureka  # 로컬에서의 eureka 설정
+
 spring:
   application:
     name: user-service
 
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:test
+    url: jdbc:h2:mem:test  # 로컬에서 H2 메모리 DB 사용
     username: sa
     password:
 
@@ -26,12 +33,12 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: update        # DB 초기화 전략 (none, create, create-drop, update, validate)
+      ddl-auto: update        # DB 초기화 전략
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
-        format_sql: true      # 쿼리 로그 포맷 (정렬)
-        show_sql: true        # 쿼리 로그 출력
+        format_sql: true
+        show_sql: true
         generate-ddl: true
 
   security:
@@ -47,7 +54,7 @@ spring:
           kakao:
             client-id: ${KAKAO_ID}
             client-secret: ${KAKAO_SECRET}
-            redirect-uri: http://43.202.23.194:8000/login/oauth2/code/kakao
+            redirect-uri: http://localhost:8000/login/oauth2/code/kakao  # 로컬 리다이렉트 URI
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
             scope:
@@ -57,19 +64,18 @@ spring:
             client-name: kakao
         provider:
           kakao:
-            authorization-uri: https://kauth.kakao.com/oauth/authorize # "인가 코드 받기" 항목
-            token-uri: https://kauth.kakao.com/oauth/token # "토큰 받기" 항목
-            user-info-uri: https://kapi.kakao.com/v2/user/me # "사용자 정보 가져오기" 항목
-            user-name-attribute: id # 식별자 . 카카오의 경우 "id" 사용
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
   cloud:
     config:
-      enabled: false
-
+      enabled: false  # 로컬 환경에서 Config 서버 비활성화
 
 logging:
   level:
     root: info
-
 
 token:
   expiration_time: 86400000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,17 +3,6 @@ spring:
     activate:
       on-profile: local
 
-server:
-  port: 8000
-
-eureka:
-  client:
-    register-with-eureka: true
-    fetch-registry: true
-    service-url:
-      defaultZone: http://localhost:8761/eureka  # 로컬에서의 eureka 설정
-
-spring:
   application:
     name: user-service
 
@@ -72,6 +61,16 @@ spring:
   cloud:
     config:
       enabled: false  # 로컬 환경에서 Config 서버 비활성화
+
+server:
+  port: 8000
+
+eureka:
+  client:
+    register-with-eureka: true
+    fetch-registry: true
+    service-url:
+      defaultZone: http://localhost:8761/eureka  # 로컬에서의 eureka 설정
 
 logging:
   level:

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -1,0 +1,10 @@
+spring:
+  config:
+    activate:
+      on-profile: prod # prod 프로파일에서만 활성화
+  cloud:
+    config:
+      uri: http://172.31.10.0:8888
+      name: user-service
+      profile: prod
+      enabled: true

--- a/src/test/java/ku/user/UserApplicationTests.java
+++ b/src/test/java/ku/user/UserApplicationTests.java
@@ -3,7 +3,7 @@ package ku.user;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(properties = "spring.profiles.active=local")
 class UserApplicationTests {
 
 	@Test

--- a/src/test/java/ku/user/user/infrastructure/UserRepositoryImplTest.java
+++ b/src/test/java/ku/user/user/infrastructure/UserRepositoryImplTest.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.*;
 
-@SpringBootTest
+@SpringBootTest(properties = "spring.profiles.active=local")
 class UserRepositoryImplTest {
     @MockBean
     private UserJpaRepository userJpaRepository;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,78 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  application:
+    name: user-service
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test  # 로컬에서 H2 메모리 DB 사용
+    username: sa
+    password:
+
+  h2:
+    console:
+      enabled: true
+      settings:
+        web-allow-others: true
+      path: /h2-console
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: update        # DB 초기화 전략
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true
+        show_sql: true
+        generate-ddl: true
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_ID}
+            client-secret: ${GOOGLE_SECRET}
+            scope:
+              - email
+              - profile
+          kakao:
+            client-id: ${KAKAO_ID}
+            client-secret: ${KAKAO_SECRET}
+            redirect-uri: http://localhost:8000/login/oauth2/code/kakao  # 로컬 리다이렉트 URI
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            scope:
+              - profile_nickname
+              - account_email
+              - profile_image
+            client-name: kakao
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+  cloud:
+    config:
+      enabled: false  # 로컬 환경에서 Config 서버 비활성화
+
+eureka:
+  client:
+    enabled: false  # 로컬 환경에서 Eureka 클라이언트 비활성화
+
+server:
+  port: 8000
+
+logging:
+  level:
+    root: info
+
+token:
+  expiration_time: 86400000
+  secret: ${SECRET}


### PR DESCRIPTION
### ✏️ 작업 개요
config를 통한 설정 파일 받기

### ⛳ 작업 분류
- [x] application.yml 프로필 나누기

### 🔨 작업 상세 내용
  1.  현재의 경우 해당 서버가 yml 파일을 가져 spring 설정들을 하게 됩니다. 여기서 이렇게 하는 것이 아닌 공통으로 관리하는 config 서버에서 가져오게 세팅을 하였습니다. 만약 로컬에서 돌린다고 하면 local profile로 할 수 있게 남겨두기는 했습니다.

### 💡 생각해볼 문제
- 아직 이것 또한 미흡한거 같은데 어떻게 더 설정 파일들을 잘 관리할 수 있을지 고민입니다.
- 또한 config 파일을 가져오는 것 또한 http 통신으로 가져와 통신 흐름에 잡힐 수도 있습니다. 더 보안을 하자면 config에서 암호화하고 user에서 복호화하는 방식으로 보안을 높일 수 있습니다.
