### PR TITLE
[Feat] prometheus를 위한 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/ku/user/UserApplication.java
+++ b/src/main/java/ku/user/UserApplication.java
@@ -2,8 +2,12 @@ package ku.user;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableDiscoveryClient
+@EnableFeignClients
 public class UserApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/ku/user/client/GameServiceClient.java
+++ b/src/main/java/ku/user/client/GameServiceClient.java
@@ -1,0 +1,11 @@
+package ku.user.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name="game-service")
+public interface GameServiceClient {
+    @GetMapping("/game-service/{userId}/games")
+    String getGameResults(@PathVariable String userId);
+}

--- a/src/main/java/ku/user/config/Resilience4JConfig.java
+++ b/src/main/java/ku/user/config/Resilience4JConfig.java
@@ -1,0 +1,35 @@
+package ku.user.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.timelimiter.TimeLimiterConfig;
+import org.springframework.cloud.circuitbreaker.resilience4j.Resilience4JCircuitBreakerFactory;
+import org.springframework.cloud.circuitbreaker.resilience4j.Resilience4JConfigBuilder;
+import org.springframework.cloud.client.circuitbreaker.Customizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+public class Resilience4JConfig {
+    @Bean
+    public Customizer<Resilience4JCircuitBreakerFactory> globalCustomConfiguration(){
+        CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
+                .failureRateThreshold(4)
+                .waitDurationInOpenState(Duration.ofMillis(1000))
+                .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+                .slidingWindowSize(2)
+                .build();
+
+        TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.custom()
+                .timeoutDuration(Duration.ofSeconds(4))
+                .build();
+
+
+        return factory -> factory.configureDefault(id -> new Resilience4JConfigBuilder(id)
+                .timeLimiterConfig(timeLimiterConfig)
+                .circuitBreakerConfig(circuitBreakerConfig)
+                .build()
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,6 +73,12 @@ logging:
   level:
     root: info
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+
 token:
   expiration_time: 86400000
   secret: ${SECRET}


### PR DESCRIPTION
### ✏️ 작업 개요
prometheus를 위한 설정 추가 및 서킷 브레이커 도입

### ⛳ 작업 분류
- [x] 의존성 추가
- [x] yaml 파일 수정
- [x] feign 관련 인터페이스 추가

### 🔨 작업 상세 내용
  1.  prometheus와 연동하기 위해 메트릭 값을 전달할 수 있게 설정하였습니다.
  2. 서킷 브레이커와 feign에 대한 작업을 간단히 완료하였습니다.

### 💡 생각해볼 문제
- 아직은 당장 사용하는 기능보다는 앞으로 사용할 것에 대한 틀 제작과 학습에 초점을 맞추었습니다. 아래에 글을 작성하였으니 참고하시면 좋을거 같습니다.
https://blog.naver.com/kamothi/223580779503 - feign
https://www.notion.so/Spring-Cloud-CircuitBreaker-08d281cc190743b2b5382388ef91c186?pvs=4
