### PR TITLE
[Feat] Spring Security 로그인 변경

### DIFF
--- a/src/main/java/ku/user/response/ApiResponse.java
+++ b/src/main/java/ku/user/response/ApiResponse.java
@@ -1,0 +1,30 @@
+package msa.userserver.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ApiResponse<T>{
+    private Boolean isSuccess;
+    private T response;
+    private ErrorResponse errorResponse;
+
+    public ApiResponse(Boolean isSuccess, T response, ErrorResponse errorResponse) {
+        this.isSuccess = isSuccess;
+        this.response = response;
+        this.errorResponse = errorResponse;
+    }
+
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    public Boolean getIsSuccess() {
+        return isSuccess;
+    }
+
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    public T getResponse() {
+        return response;
+    }
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    public ErrorResponse getErrorResponse() {
+        return errorResponse;
+    }
+}

--- a/src/main/java/ku/user/response/ApiResponse.java
+++ b/src/main/java/ku/user/response/ApiResponse.java
@@ -1,7 +1,6 @@
-package msa.userserver.dto.response;
+package ku.user.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ApiResponse<T>{
     private Boolean isSuccess;

--- a/src/main/java/ku/user/response/ApiResponse.java
+++ b/src/main/java/ku/user/response/ApiResponse.java
@@ -13,16 +13,16 @@ public class ApiResponse<T>{
         this.errorResponse = errorResponse;
     }
 
-    @JsonInclude(JsonInclude.Include.ALWAYS)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public Boolean getIsSuccess() {
         return isSuccess;
     }
 
-    @JsonInclude(JsonInclude.Include.ALWAYS)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public T getResponse() {
         return response;
     }
-    @JsonInclude(JsonInclude.Include.ALWAYS)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public ErrorResponse getErrorResponse() {
         return errorResponse;
     }

--- a/src/main/java/ku/user/response/ErrorResponse.java
+++ b/src/main/java/ku/user/response/ErrorResponse.java
@@ -1,0 +1,12 @@
+package msa.userserver.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+    private String message;
+
+    public ErrorResponse(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/ku/user/response/ErrorResponse.java
+++ b/src/main/java/ku/user/response/ErrorResponse.java
@@ -1,4 +1,4 @@
-package msa.userserver.dto.response;
+package ku.user.response;
 
 import lombok.Getter;
 

--- a/src/main/java/ku/user/security/AuthenticationFilter.java
+++ b/src/main/java/ku/user/security/AuthenticationFilter.java
@@ -1,0 +1,115 @@
+package ku.user.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import ku.user.response.ApiResponse;
+import ku.user.user.domain.RequestLogin;
+import ku.user.user.domain.UserDto;
+import ku.user.user.infrastructure.entity.UserEntity;
+import ku.user.user.infrastructure.repository.UserRepository;
+import ku.user.user.service.UserService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+
+@Slf4j
+public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private UserService userService;
+    private UserRepository userRepository;
+    private Environment env;
+
+    public AuthenticationFilter(AuthenticationManager authenticationManager, UserService userService, UserRepository userRepository, Environment env) {
+        super.setAuthenticationManager(authenticationManager);
+        this.userService = userService;
+        this.userRepository = userRepository;
+        this.env = env;
+    }
+
+
+
+    // 요청 정보를 보냈을 때 처리하는 메서드
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request,
+                                                HttpServletResponse response) throws AuthenticationException {
+        try{
+            RequestLogin creds = new ObjectMapper().readValue(request.getInputStream(),RequestLogin.class);
+            request.setAttribute("requestLogin", creds);
+            // 입력 받은 이메일과 비밀번호를 spring security에서 사용할 수 있는 형태로 변경해줘야함.
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            creds.getEmail(),
+                            creds.getPassword(),
+                            new ArrayList<>()
+                    )
+            );
+        }catch (IOException e){
+            throw new RuntimeException(e);
+        }
+    }
+
+    // 실제 인증처리가 성공했을 때 어떤 처리를 해줄 것인지(토큰을 만든다거나 반환값을 뭘 줄 것인가)
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request,
+                                            HttpServletResponse response,
+                                            FilterChain chain,
+                                            Authentication authResult) throws IOException, ServletException {
+
+        String userName = (((User)authResult.getPrincipal()).getUsername());
+        UserDto userDetails = userService.getUserDetailsByEmail(userName);
+        UserEntity userEntity = userRepository.findByEmail(userName).get();
+        ObjectMapper objectMapper = new ObjectMapper();
+        ApiResponse<String> apiResponse;
+
+        response.setCharacterEncoding("UTF-8"); // 문자 인코딩 설정
+
+
+        if (userEntity.getPassword().getFailedCount() > 5) {
+            // 비밀번호 재설정이 필요한 경우에 대한 처리
+            apiResponse = new ApiResponse<>(false, "비밀번호재설정", null);
+
+            String jsonResponse = objectMapper.writeValueAsString(apiResponse);
+            response.getWriter().write(jsonResponse);
+            return;
+        }
+        if(userEntity.getPassword().isExpiration()){
+            apiResponse = new ApiResponse<>(false, "만료되었음", null);
+
+            String jsonResponse = objectMapper.writeValueAsString(apiResponse);
+            response.getWriter().write(jsonResponse);
+            return;
+        }
+
+        userEntity.getPassword().updateFailedCount(true);
+        userRepository.save(userEntity);
+
+        String token = Jwts.builder()
+                .setSubject(userDetails.getEmail())
+                .setExpiration(new Date(System.currentTimeMillis() +
+                        Long.parseLong(env.getProperty("token.expiration_time"))))
+                .signWith(SignatureAlgorithm.HS512,env.getProperty("token.secret"))
+                .compact();
+
+        response.addHeader("token",token);
+        response.addHeader("email",userDetails.getEmail());
+        apiResponse = new ApiResponse<>(true, "로그인 성공", null);
+
+        String jsonResponse = objectMapper.writeValueAsString(apiResponse);
+        response.getWriter().write(jsonResponse);
+
+    }
+}
+

--- a/src/main/java/ku/user/security/CustomLoginFailureHandler.java
+++ b/src/main/java/ku/user/security/CustomLoginFailureHandler.java
@@ -1,0 +1,73 @@
+package ku.user.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import ku.user.response.ApiResponse;
+import ku.user.response.ErrorResponse;
+import ku.user.user.domain.RequestLogin;
+import ku.user.user.infrastructure.entity.UserEntity;
+import ku.user.user.infrastructure.repository.UserRepository;
+import ku.user.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class CustomLoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+    private final UserService userService;
+    private final UserRepository userRepository;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        String errorMessage;
+        if (exception instanceof BadCredentialsException) {
+            errorMessage = "아이디 또는 비밀번호가 맞지 않습니다. 다시 확인해 주세요.";
+        } else if (exception instanceof InternalAuthenticationServiceException) {
+            errorMessage = "내부적으로 발생한 시스템 문제로 인해 요청을 처리할 수 없습니다. 관리자에게 문의하세요.";
+        } else if (exception instanceof UsernameNotFoundException) {
+            errorMessage = "계정이 존재하지 않습니다. 회원가입 진행 후 로그인 해주세요.";
+        } else if (exception instanceof AuthenticationCredentialsNotFoundException) {
+            errorMessage = "인증 요청이 거부되었습니다. 관리자에게 문의하세요.";
+        } else {
+            errorMessage = "알 수 없는 이유로 로그인에 실패하였습니다 관리자에게 문의하세요.";
+        }
+
+        RequestLogin creds = (RequestLogin) request.getAttribute("requestLogin");
+        String email = creds.getEmail();
+        UserEntity userEntity = userRepository.findByEmail(email).get();
+
+        if (userEntity != null) {
+            userEntity.getPassword().updateFailedCount(false);
+            userRepository.save(userEntity);
+        }
+        if(userEntity.getPassword().getFailedCount() > 5){
+            errorMessage = "5회 초과하였습니다.";
+        }
+
+
+        response.setCharacterEncoding("UTF-8"); // 문자 인코딩 설정
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // HTTP 상태 코드 설정
+        response.setContentType("application/json"); // 응답 형식 설정 (예: 텍스트)
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        ApiResponse<String> apiResponse = new ApiResponse<>(false, null, new ErrorResponse(errorMessage));
+        Map<String, Object> errorMap = Collections.singletonMap("error", apiResponse);
+        String jsonResponse = objectMapper.writeValueAsString(apiResponse);
+        response.getWriter().write(jsonResponse); // 응답 본문에 에러 메시지 작성
+    }
+}
+

--- a/src/main/java/ku/user/security/WebSecurity.java
+++ b/src/main/java/ku/user/security/WebSecurity.java
@@ -1,0 +1,72 @@
+package ku.user.security;
+
+import ku.user.user.infrastructure.repository.UserRepository;
+import ku.user.user.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.env.Environment;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurity {
+
+    private final UserService userService;
+    private final UserRepository userRepository;
+    private final Environment env;
+
+    public WebSecurity(UserService userService, UserRepository userRepository, Environment env) {
+        this.userService = userService;
+        this.userRepository = userRepository;
+        this.env = env;
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .headers(header -> header.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/h2-console/**").permitAll()
+                        .requestMatchers("/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+//                .formLogin(form -> form.disable())
+//                .formLogin(form -> form
+//                        .disable()
+////                        .failureHandler(new CustomLoginFailureHandler(userService,userRepository))
+//                )
+                .addFilter(getAuthenticationFilter(authManager(http.getSharedObject(AuthenticationConfiguration.class))));
+
+        return http.build();
+    }
+
+    public AuthenticationFilter getAuthenticationFilter(AuthenticationManager authenticationManager) {
+        AuthenticationFilter authenticationFilter = new AuthenticationFilter(authenticationManager,userService,userRepository,env);
+        authenticationFilter.setAuthenticationFailureHandler(new CustomLoginFailureHandler(userService,userRepository));
+        return  authenticationFilter;
+    }
+
+    @Bean
+    public AuthenticationManager authManager(AuthenticationConfiguration authConfig) throws Exception {
+        return authConfig.getAuthenticationManager(); // Directly get the AuthenticationManager
+    }
+
+
+}

--- a/src/main/java/ku/user/user/controller/UserController.java
+++ b/src/main/java/ku/user/user/controller/UserController.java
@@ -2,6 +2,7 @@ package ku.user.user.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import ku.user.response.ApiResponse;
 import ku.user.user.domain.CreateUser;
 import ku.user.user.infrastructure.entity.UserEntity;
 import ku.user.user.service.UserService;
@@ -23,10 +24,10 @@ public class UserController {
     }
 
     @PostMapping("/sign")
-    public ResponseEntity<UserEntity> sign(@RequestBody CreateUser createUser){
+    public ApiResponse<String> sign(@RequestBody CreateUser createUser){
         UserEntity userEntity = userService.create(createUser);
         log.info(userEntity.toString());
-        return ResponseEntity.status(HttpStatus.CREATED).body(userEntity);
+        return new ApiResponse<>(true,"가입 성공하였습니다.",null);
     }
 
     @GetMapping("/success")

--- a/src/main/java/ku/user/user/controller/UserController.java
+++ b/src/main/java/ku/user/user/controller/UserController.java
@@ -2,24 +2,17 @@ package ku.user.user.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import ku.user.user.domain.CreateUser;
 import ku.user.user.infrastructure.entity.UserEntity;
 import ku.user.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
-import java.net.http.HttpResponse;
-
-@Controller
+@RestController
 @Slf4j
-@RequestMapping("/login")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
@@ -27,6 +20,13 @@ public class UserController {
     @GetMapping("")
     public String loginView() {
         return "/login2";
+    }
+
+    @PostMapping("/sign")
+    public ResponseEntity<UserEntity> sign(@RequestBody CreateUser createUser){
+        UserEntity userEntity = userService.create(createUser);
+        log.info(userEntity.toString());
+        return ResponseEntity.status(HttpStatus.CREATED).body(userEntity);
     }
 
     @GetMapping("/success")

--- a/src/main/java/ku/user/user/domain/CreateUser.java
+++ b/src/main/java/ku/user/user/domain/CreateUser.java
@@ -3,6 +3,8 @@ package ku.user.user.domain;
 import ku.user.user.infrastructure.entity.UserEntity;
 import lombok.Builder;
 
+import java.time.LocalDateTime;
+
 public class CreateUser {
 
     private String email;
@@ -21,6 +23,7 @@ public class CreateUser {
                 .email(email)
                 .password(password)
                 .nickname(nickname)
+                .lastLoginAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/ku/user/user/domain/RequestLogin.java
+++ b/src/main/java/ku/user/user/domain/RequestLogin.java
@@ -1,0 +1,13 @@
+package ku.user.user.domain;
+
+import lombok.Data;
+import org.antlr.v4.runtime.misc.NotNull;
+
+@Data
+public class RequestLogin {
+    @NotNull
+    private String email;
+
+    @NotNull
+    private String password;
+}

--- a/src/main/java/ku/user/user/domain/UserDto.java
+++ b/src/main/java/ku/user/user/domain/UserDto.java
@@ -1,0 +1,39 @@
+package ku.user.user.domain;
+
+import ku.user.user.infrastructure.entity.UserEntity;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Date;
+import java.util.List;
+
+@Data
+public class UserDto {
+    private String email;
+    private String name;
+    private Date createdAt;
+    private String password;
+
+    @Builder
+    public UserDto(String name, String email, String password) {
+        this.name = name;
+        this.email = email;
+        this.password = password;
+    }
+
+    public static UserDto from(UserEntity userEntity) {
+        return UserDto.builder()
+                .name(userEntity.getNickname())
+                .email(userEntity.getEmail())
+                .build();
+    }
+
+    public UserEntity toEntity() {
+        return UserEntity.builder()
+                .nickname(name)
+                .email(email)
+                .password(password)
+                .build();
+    }
+
+}

--- a/src/main/java/ku/user/user/infrastructure/entity/UserEntity.java
+++ b/src/main/java/ku/user/user/infrastructure/entity/UserEntity.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.Clock;
+import java.time.LocalDateTime;
 
 @Entity
 @Data
@@ -31,13 +32,14 @@ public class UserEntity {
     private UserStatus status;
 
     @Column(name = "last_login_at")
-    private Long lastLoginAt;
+    LocalDateTime lastLoginAt;
 
     @Builder
-    public UserEntity(String email, String nickname, String password, Long id) {
+    public UserEntity(String email, String nickname, String password, Long id, LocalDateTime lastLoginAt) {
         this.id = id;
         this.email = email;
         this.nickname = nickname;
+        this.lastLoginAt = lastLoginAt;
         this.password = password != null ? new Password(password, Clock.systemDefaultZone()) : new Password("",Clock.systemDefaultZone()); // 빈 문자열로 초기화
         this.status = UserStatus.GENERAL;
     }

--- a/src/main/java/ku/user/user/service/UserService.java
+++ b/src/main/java/ku/user/user/service/UserService.java
@@ -2,6 +2,7 @@ package ku.user.user.service;
 
 import ku.user.user.domain.CreateUser;
 import ku.user.user.domain.UpdateUser;
+import ku.user.user.domain.UserDto;
 import ku.user.user.infrastructure.entity.UserEntity;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
@@ -12,6 +13,8 @@ public interface UserService extends UserDetailsService {
     UserEntity getByEmail(String email);
     UserEntity update(Long id, UpdateUser updateUserDto);
     void delete(Long id/*, 여기에 인증으로 삭제하게 할까?(등록했던 이메일로) */);
+
+    UserDto getUserDetailsByEmail(String userName);
 
 
     // 비밀번호 찾기 -> 아마 이거는 찾기보다는 재설정이 맞을거 같음 (메일을 보낸다면 MailSender 사용해야함)

--- a/src/main/java/ku/user/user/service/UserServiceImpl.java
+++ b/src/main/java/ku/user/user/service/UserServiceImpl.java
@@ -3,23 +3,36 @@ package ku.user.user.service;
 import jakarta.transaction.Transactional;
 import ku.user.user.domain.CreateUser;
 import ku.user.user.domain.UpdateUser;
+import ku.user.user.domain.UserDto;
 import ku.user.user.infrastructure.entity.UserEntity;
 import ku.user.user.infrastructure.repository.UserRepository;
 import ku.user.user.service.exception.ResourceNotFoundException;
 import ku.user.user.service.exception.UserExistsException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService{
     private final UserRepository userRepository;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return null;
+        UserEntity user = userRepository.findByEmail(username).get();
+
+        if(user == null){
+            throw new UsernameNotFoundException(username);
+        }
+        // 마지막 어레이는 로그인 되었을 때 그 다음에 할 수 있는 작업에서의 권한 추가
+        return new User(user.getEmail(),user.getPassword().getPassword()
+                ,true,true,true,true,new ArrayList<>());
     }
 
     @Override
@@ -67,5 +80,15 @@ public class UserServiceImpl implements UserService{
     @Override
     public void delete(Long id) {
         // 인증해야지만 삭제하게 할 것인가?
+    }
+
+    @Override
+    public UserDto getUserDetailsByEmail(String email) {
+        UserEntity user = userRepository.findByEmail(email).get();
+
+        if(user == null)
+            throw new UsernameNotFoundException(email);
+
+        return UserDto.from(user);
     }
 }


### PR DESCRIPTION
### ✏️ 작업 개요
기존 OAuth를 이용한 로그인에서 Spring Security 로그인으로 변경

### ⛳ 작업 분류
- [x] Websecuriy 설정 파일 추가
- [x] 실패 핸들러 및 filter 추가
- [x] response 형식 추가

### 🔨 작업 상세 내용
  1. 기존의 경우 OAuth2 설정들을 통해 카카오와 구글 로그인으로 진행을 하였습니다. 하지만 클라이언트에서 해당 로직으로 수행하기 어렵기에 자체 로그인을 하되 Spring Securiy를 활용하여 인증/인가 처리를 구현하였습니다.
  2. 실패시에는 여러 로직들을 추가했고 여러 번 실패하는지와 같은 처리를 구성하였습니다.
  3. 기존 일관적이지 못한 response 형식을 통일화하였습니다.

### 💡 생각해볼 문제
- 냉무
