### PR TITLE
[Feat] sologame 기록 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/ku/user/domain/Ranking/controller/RhythmScoreController.java
+++ b/src/main/java/ku/user/domain/Ranking/controller/RhythmScoreController.java
@@ -1,0 +1,32 @@
+package ku.user.domain.Ranking.controller;
+
+import ku.user.domain.Ranking.domain.RhythmScore;
+import ku.user.domain.Ranking.domain.SteppingStonesScore;
+import ku.user.domain.Ranking.dto.request.SaveRhythmRequest;
+import ku.user.domain.Ranking.dto.request.SaveSteppingRequest;
+import ku.user.domain.Ranking.dto.response.SaveRhythmResponse;
+import ku.user.domain.Ranking.dto.response.SaveSteppingResponse;
+import ku.user.domain.Ranking.service.RhythmScoreService;
+import ku.user.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RhythmScoreController {
+    private final RhythmScoreService rhythmScoreService;
+
+    // 저장
+    @PostMapping("/rhythm")
+    public ApiResponse<SaveRhythmResponse> saveStepping(@RequestBody SaveRhythmRequest saveSteppingRequest){
+        RhythmScore rhythmScore = SaveRhythmRequest.toEntity(saveSteppingRequest);
+        RhythmScore savedScore = rhythmScoreService.saveScore(rhythmScore);
+        SaveRhythmResponse response = SaveRhythmResponse.fromEntity(savedScore);
+
+        return new ApiResponse<>(true, response, null);
+    }
+
+
+}

--- a/src/main/java/ku/user/domain/Ranking/controller/SteppingStonesScoreController.java
+++ b/src/main/java/ku/user/domain/Ranking/controller/SteppingStonesScoreController.java
@@ -1,0 +1,26 @@
+package ku.user.domain.Ranking.controller;
+
+import ku.user.domain.Ranking.domain.SteppingStonesScore;
+import ku.user.domain.Ranking.dto.request.SaveSteppingRequest;
+import ku.user.domain.Ranking.dto.response.SaveSteppingResponse;
+import ku.user.domain.Ranking.service.SteppingStonesScoreService;
+import ku.user.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SteppingStonesScoreController {
+    private final SteppingStonesScoreService steppingStonesScoreService;
+    // 저장
+    @PostMapping("/stepping")
+    public ApiResponse<SaveSteppingResponse> saveStepping(@RequestBody SaveSteppingRequest saveSteppingRequest){
+        SteppingStonesScore steppingStonesScore = SaveSteppingRequest.toEntity(saveSteppingRequest);
+        SteppingStonesScore savedScore = steppingStonesScoreService.saveScore(steppingStonesScore);
+        SaveSteppingResponse response = SaveSteppingResponse.fromEntity(savedScore);
+
+        return new ApiResponse<>(true, response, null);
+    }
+}

--- a/src/main/java/ku/user/domain/Ranking/domain/RhythmScore.java
+++ b/src/main/java/ku/user/domain/Ranking/domain/RhythmScore.java
@@ -2,6 +2,7 @@ package ku.user.domain.Ranking.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 // 점수, 캐릭터명, 날짜, 재화
@@ -16,9 +17,17 @@ public class RhythmScore {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "nickname", nullable = false, length = 50)
     private String nickName;
 
+    @Column(nullable = false)
     private int score;
 
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @CreationTimestamp
     private LocalDateTime createdAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private Status status = Status.ACTIVE;
 }

--- a/src/main/java/ku/user/domain/Ranking/domain/RhythmScore.java
+++ b/src/main/java/ku/user/domain/Ranking/domain/RhythmScore.java
@@ -1,0 +1,24 @@
+package ku.user.domain.Ranking.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+// 점수, 캐릭터명, 날짜, 재화
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@Table(name = "rhythm_scores")
+public class RhythmScore {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nickName;
+
+    private int score;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/ku/user/domain/Ranking/domain/RhythmScore.java
+++ b/src/main/java/ku/user/domain/Ranking/domain/RhythmScore.java
@@ -27,7 +27,9 @@ public class RhythmScore {
     @CreationTimestamp
     private LocalDateTime createdAt;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private Status status = Status.ACTIVE;
+
 }

--- a/src/main/java/ku/user/domain/Ranking/domain/Status.java
+++ b/src/main/java/ku/user/domain/Ranking/domain/Status.java
@@ -2,7 +2,6 @@ package ku.user.domain.Ranking.domain;
 
 public enum Status {
     ACTIVE("활성화"),
-    DELETED("삭제됨"),
     INACTIVE("비활성화");
 
     private final String description;

--- a/src/main/java/ku/user/domain/Ranking/domain/Status.java
+++ b/src/main/java/ku/user/domain/Ranking/domain/Status.java
@@ -1,0 +1,18 @@
+package ku.user.domain.Ranking.domain;
+
+public enum Status {
+    ACTIVE("활성화"),
+    DELETED("삭제됨"),
+    INACTIVE("비활성화");
+
+    private final String description;
+
+    Status(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}
+

--- a/src/main/java/ku/user/domain/Ranking/domain/SteppingStonesScore.java
+++ b/src/main/java/ku/user/domain/Ranking/domain/SteppingStonesScore.java
@@ -1,0 +1,26 @@
+package ku.user.domain.Ranking.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@Table(name = "stepping_stones_score")
+public class SteppingStonesScore {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nickName;
+
+    private int score;
+
+    private int coin;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/ku/user/domain/Ranking/domain/SteppingStonesScore.java
+++ b/src/main/java/ku/user/domain/Ranking/domain/SteppingStonesScore.java
@@ -2,6 +2,7 @@ package ku.user.domain.Ranking.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -16,11 +17,20 @@ public class SteppingStonesScore {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "nickname", nullable = false, length = 50)
     private String nickName;
 
+    @Column(nullable = false)
     private int score;
 
+    @Column(nullable = false)
     private int coin;
 
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @CreationTimestamp
     private LocalDateTime createdAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private Status status = Status.ACTIVE;
 }

--- a/src/main/java/ku/user/domain/Ranking/domain/SteppingStonesScore.java
+++ b/src/main/java/ku/user/domain/Ranking/domain/SteppingStonesScore.java
@@ -30,6 +30,7 @@ public class SteppingStonesScore {
     @CreationTimestamp
     private LocalDateTime createdAt;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private Status status = Status.ACTIVE;

--- a/src/main/java/ku/user/domain/Ranking/dto/request/SaveRhythmRequest.java
+++ b/src/main/java/ku/user/domain/Ranking/dto/request/SaveRhythmRequest.java
@@ -1,0 +1,24 @@
+package ku.user.domain.Ranking.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import ku.user.domain.Ranking.domain.RhythmScore;
+import lombok.Getter;
+
+@Getter
+public class SaveRhythmRequest {
+    @NotBlank(message = "닉네임은 필수 항목")
+    private String nickName;
+
+    @Min(value = 0, message = "점수는 0 이상이어야 합니다.")
+    private int score;
+
+
+    public static RhythmScore toEntity(SaveRhythmRequest saveRhythmRequest){
+        return RhythmScore.builder()
+                .nickName(saveRhythmRequest.getNickName())
+                .score(saveRhythmRequest.getScore())
+                .build();
+
+    }
+}

--- a/src/main/java/ku/user/domain/Ranking/dto/request/SaveRhythmRequest.java
+++ b/src/main/java/ku/user/domain/Ranking/dto/request/SaveRhythmRequest.java
@@ -3,6 +3,7 @@ package ku.user.domain.Ranking.dto.request;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import ku.user.domain.Ranking.domain.RhythmScore;
+import ku.user.domain.Ranking.domain.Status;
 import lombok.Getter;
 
 @Getter
@@ -18,6 +19,7 @@ public class SaveRhythmRequest {
         return RhythmScore.builder()
                 .nickName(saveRhythmRequest.getNickName())
                 .score(saveRhythmRequest.getScore())
+                .status(Status.ACTIVE)
                 .build();
 
     }

--- a/src/main/java/ku/user/domain/Ranking/dto/request/SaveSteppingRequest.java
+++ b/src/main/java/ku/user/domain/Ranking/dto/request/SaveSteppingRequest.java
@@ -2,6 +2,7 @@ package ku.user.domain.Ranking.dto.request;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import ku.user.domain.Ranking.domain.Status;
 import ku.user.domain.Ranking.domain.SteppingStonesScore;
 import lombok.Getter;
 
@@ -21,6 +22,7 @@ public class SaveSteppingRequest {
                 .nickName(saveSteppingRequest.getNickName())
                 .score(saveSteppingRequest.getScore())
                 .coin(saveSteppingRequest.getCoin())
+                .status(Status.ACTIVE)
                 .build();
 
     }

--- a/src/main/java/ku/user/domain/Ranking/dto/request/SaveSteppingRequest.java
+++ b/src/main/java/ku/user/domain/Ranking/dto/request/SaveSteppingRequest.java
@@ -1,0 +1,27 @@
+package ku.user.domain.Ranking.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import ku.user.domain.Ranking.domain.SteppingStonesScore;
+import lombok.Getter;
+
+@Getter
+public class SaveSteppingRequest {
+    @NotBlank(message = "닉네임은 필수 항목")
+    private String nickName;
+
+    @Min(value = 0, message = "점수는 0 이상이어야 합니다.")
+    private int score;
+
+    @Min(value = 0, message = "코인은 0 이상이어야 합니다.")
+    private int coin;
+
+    public static SteppingStonesScore toEntity(SaveSteppingRequest saveSteppingRequest){
+        return SteppingStonesScore.builder()
+                .nickName(saveSteppingRequest.getNickName())
+                .score(saveSteppingRequest.getScore())
+                .coin(saveSteppingRequest.getCoin())
+                .build();
+
+    }
+}

--- a/src/main/java/ku/user/domain/Ranking/dto/response/SaveRhythmResponse.java
+++ b/src/main/java/ku/user/domain/Ranking/dto/response/SaveRhythmResponse.java
@@ -1,0 +1,14 @@
+package ku.user.domain.Ranking.dto.response;
+
+import ku.user.domain.Ranking.domain.RhythmScore;
+import ku.user.domain.Ranking.domain.SteppingStonesScore;
+
+public record SaveRhythmResponse(Long id, String nickName, int score) {
+    public static SaveRhythmResponse fromEntity(RhythmScore rhythmScore) {
+        return new SaveRhythmResponse(
+                rhythmScore.getId(),
+                rhythmScore.getNickName(),
+                rhythmScore.getScore()
+        );
+    }
+}

--- a/src/main/java/ku/user/domain/Ranking/dto/response/SaveSteppingResponse.java
+++ b/src/main/java/ku/user/domain/Ranking/dto/response/SaveSteppingResponse.java
@@ -1,0 +1,14 @@
+package ku.user.domain.Ranking.dto.response;
+
+import ku.user.domain.Ranking.domain.SteppingStonesScore;
+
+public record SaveSteppingResponse(Long id, String nickName, int score, int coin) {
+    public static SaveSteppingResponse fromEntity(SteppingStonesScore steppingStonesScore) {
+        return new SaveSteppingResponse(
+                steppingStonesScore.getId(),
+                steppingStonesScore.getNickName(),
+                steppingStonesScore.getScore(),
+                steppingStonesScore.getCoin()
+        );
+    }
+}

--- a/src/main/java/ku/user/domain/Ranking/infrastructure/RhythmScoreRepository.java
+++ b/src/main/java/ku/user/domain/Ranking/infrastructure/RhythmScoreRepository.java
@@ -4,7 +4,7 @@ import ku.user.domain.Ranking.domain.RhythmScore;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,5 +14,5 @@ public interface RhythmScoreRepository extends JpaRepository<RhythmScore,Long> {
 
     Optional<RhythmScore> findTopByNickNameOrderByScoreDesc(String nickName);
 
-    List<RhythmScore> findByNickNameAndCreatedAtDate(String nickName, LocalDate date);
+    List<RhythmScore> findByNickNameAndCreatedAtBetween(String nickName, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/ku/user/domain/Ranking/infrastructure/RhythmScoreRepository.java
+++ b/src/main/java/ku/user/domain/Ranking/infrastructure/RhythmScoreRepository.java
@@ -1,0 +1,18 @@
+package ku.user.domain.Ranking.infrastructure;
+
+import ku.user.domain.Ranking.domain.RhythmScore;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface RhythmScoreRepository extends JpaRepository<RhythmScore,Long> {
+    List<RhythmScore> findRhythmScoresByNickName(String nickname);
+
+    Optional<RhythmScore> findTopByNickNameOrderByScoreDesc(String nickName);
+
+    List<RhythmScore> findByNickNameAndCreatedAtDate(String nickName, LocalDate date);
+}

--- a/src/main/java/ku/user/domain/Ranking/infrastructure/SteppingScoreRepository.java
+++ b/src/main/java/ku/user/domain/Ranking/infrastructure/SteppingScoreRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,5 +16,5 @@ public interface SteppingScoreRepository extends JpaRepository<SteppingStonesSco
 
     Optional<SteppingStonesScore> findTopByNickNameOrderByScoreDesc(String nickName);
 
-    List<SteppingStonesScore> findByNickNameAndCreatedAtDate(String nickName, LocalDate date);
+    List<SteppingStonesScore> findByNickNameAndCreatedAtBetween(String nickName, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/ku/user/domain/Ranking/infrastructure/SteppingScoreRepository.java
+++ b/src/main/java/ku/user/domain/Ranking/infrastructure/SteppingScoreRepository.java
@@ -1,0 +1,19 @@
+package ku.user.domain.Ranking.infrastructure;
+
+import ku.user.domain.Ranking.domain.RhythmScore;
+import ku.user.domain.Ranking.domain.SteppingStonesScore;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SteppingScoreRepository extends JpaRepository<SteppingStonesScore,Long> {
+    List<SteppingStonesScore> findSteppingStonesScoresByNickName(String nickname);
+
+    Optional<SteppingStonesScore> findTopByNickNameOrderByScoreDesc(String nickName);
+
+    List<SteppingStonesScore> findByNickNameAndCreatedAtDate(String nickName, LocalDate date);
+}

--- a/src/main/java/ku/user/domain/Ranking/service/RhythmScoreService.java
+++ b/src/main/java/ku/user/domain/Ranking/service/RhythmScoreService.java
@@ -1,0 +1,24 @@
+package ku.user.domain.Ranking.service;
+
+import ku.user.domain.Ranking.domain.RhythmScore;
+import ku.user.domain.Ranking.domain.Status;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface RhythmScoreService {
+    // 생성
+    RhythmScore saveScore();
+
+    // 조회(해당 캐릭터의 모든 기록)
+    List<RhythmScore> findScoresByNickName(String nickName);
+
+    // 조회(해당 캐릭터의 특정 날짜 기록)
+    List<RhythmScore> findScoresByNickNameAndDate(String nickName, LocalDate date);
+
+    // 캐릭터 삭제
+    void updateScoreStatus(String nickName);
+
+    // 해당 캐릭터의 최고 기록
+    RhythmScore findHighestScoreByNickName(String nickName);
+}

--- a/src/main/java/ku/user/domain/Ranking/service/RhythmScoreService.java
+++ b/src/main/java/ku/user/domain/Ranking/service/RhythmScoreService.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface RhythmScoreService {
     // 생성
-    RhythmScore saveScore();
+    RhythmScore saveScore(RhythmScore rhythmScore);
 
     // 조회(해당 캐릭터의 모든 기록)
     List<RhythmScore> findScoresByNickName(String nickName);

--- a/src/main/java/ku/user/domain/Ranking/service/RhythmScoreService.java
+++ b/src/main/java/ku/user/domain/Ranking/service/RhythmScoreService.java
@@ -4,6 +4,7 @@ import ku.user.domain.Ranking.domain.RhythmScore;
 import ku.user.domain.Ranking.domain.Status;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface RhythmScoreService {
@@ -14,7 +15,7 @@ public interface RhythmScoreService {
     List<RhythmScore> findScoresByNickName(String nickName);
 
     // 조회(해당 캐릭터의 특정 날짜 기록)
-    List<RhythmScore> findScoresByNickNameAndDate(String nickName, LocalDate date);
+    List<RhythmScore> findScoresByNickNameAndDate(String nickName, LocalDateTime startDate, LocalDateTime endDate);
 
     // 캐릭터 삭제
     void updateScoreStatus(String nickName);

--- a/src/main/java/ku/user/domain/Ranking/service/RhythmScoreServiceImpl.java
+++ b/src/main/java/ku/user/domain/Ranking/service/RhythmScoreServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,8 +29,8 @@ public class RhythmScoreServiceImpl implements RhythmScoreService{
     }
 
 
-    public List<RhythmScore> findScoresByNickNameAndDate(String nickName, LocalDate date) {
-        return repository.findByNickNameAndCreatedAtDate(nickName, date);
+    public List<RhythmScore> findScoresByNickNameAndDate(String nickName, LocalDateTime startDate, LocalDateTime endDate) {
+        return repository.findByNickNameAndCreatedAtBetween(nickName, startDate, endDate);
     }
 
     @Transactional

--- a/src/main/java/ku/user/domain/Ranking/service/RhythmScoreServiceImpl.java
+++ b/src/main/java/ku/user/domain/Ranking/service/RhythmScoreServiceImpl.java
@@ -1,0 +1,64 @@
+package ku.user.domain.Ranking.service;
+
+import ku.user.domain.Ranking.domain.RhythmScore;
+import ku.user.domain.Ranking.domain.Status;
+import ku.user.domain.Ranking.infrastructure.RhythmScoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RhythmScoreServiceImpl implements RhythmScoreService{
+    private final RhythmScoreRepository repository;
+
+    @Transactional
+    public RhythmScore saveScore(RhythmScore rhythmScore) {
+        return repository.save(rhythmScore);
+    }
+
+
+    public List<RhythmScore> findScoresByNickName(String nickName) {
+        List<RhythmScore> scores = repository.findRhythmScoresByNickName(nickName);
+        return scores;
+    }
+
+
+    public List<RhythmScore> findScoresByNickNameAndDate(String nickName, LocalDate date) {
+        return repository.findByNickNameAndCreatedAtDate(nickName, date);
+    }
+
+    @Transactional
+    public void updateScoreStatus(String nickName) {
+        List<RhythmScore> scores = repository.findRhythmScoresByNickName(nickName);
+
+        if (scores.isEmpty()) {
+            throw new IllegalArgumentException("해당 닉네임의 기록은 존재하지 않음: " + nickName);
+        }
+
+        boolean hasActiveRecord = false;
+        for (RhythmScore score : scores) {
+            if (score.getStatus() == Status.ACTIVE) {
+                score.setStatus(Status.INACTIVE);
+                hasActiveRecord = true;
+            }
+        }
+
+        if (!hasActiveRecord) {
+            System.out.println("이미 비활성화 되어 있는 캐릭터입니다.");
+            return;
+        }
+
+        repository.saveAll(scores);
+    }
+
+
+    public RhythmScore findHighestScoreByNickName(String nickName) {
+        Optional<RhythmScore> optionalScore = repository.findTopByNickNameOrderByScoreDesc(nickName);
+        return optionalScore.orElse(null);
+    }
+}

--- a/src/main/java/ku/user/domain/Ranking/service/SteppingStonesScoreService.java
+++ b/src/main/java/ku/user/domain/Ranking/service/SteppingStonesScoreService.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface SteppingStonesScoreService {
     // 생성
-    SteppingStonesScore saveScore();
+    SteppingStonesScore saveScore(SteppingStonesScore steppingStonesScore);
 
     // 조회(해당 캐릭터의 모든 기록)
     List<SteppingStonesScore> findScoresByNickName(String nickName);

--- a/src/main/java/ku/user/domain/Ranking/service/SteppingStonesScoreService.java
+++ b/src/main/java/ku/user/domain/Ranking/service/SteppingStonesScoreService.java
@@ -3,6 +3,7 @@ package ku.user.domain.Ranking.service;
 import ku.user.domain.Ranking.domain.SteppingStonesScore;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface SteppingStonesScoreService {
@@ -13,7 +14,7 @@ public interface SteppingStonesScoreService {
     List<SteppingStonesScore> findScoresByNickName(String nickName);
 
     // 조회(해당 캐릭터의 특정 날짜 기록)
-    List<SteppingStonesScore> findScoresByNickNameAndDate(String nickName, LocalDate date);
+    List<SteppingStonesScore> findScoresByNickNameAndDate(String nickName, LocalDateTime startDate, LocalDateTime endDate);
 
     // 캐릭터 삭제
     void updateScoreStatus(String nickName);

--- a/src/main/java/ku/user/domain/Ranking/service/SteppingStonesScoreService.java
+++ b/src/main/java/ku/user/domain/Ranking/service/SteppingStonesScoreService.java
@@ -1,0 +1,23 @@
+package ku.user.domain.Ranking.service;
+
+import ku.user.domain.Ranking.domain.SteppingStonesScore;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface SteppingStonesScoreService {
+    // 생성
+    SteppingStonesScore saveScore();
+
+    // 조회(해당 캐릭터의 모든 기록)
+    List<SteppingStonesScore> findScoresByNickName(String nickName);
+
+    // 조회(해당 캐릭터의 특정 날짜 기록)
+    List<SteppingStonesScore> findScoresByNickNameAndDate(String nickName, LocalDate date);
+
+    // 캐릭터 삭제
+    void updateScoreStatus(String nickName);
+
+    // 해당 캐릭터의 최고 기록
+    SteppingStonesScore findHighestScoreByNickName(String nickName);
+}

--- a/src/main/java/ku/user/domain/Ranking/service/SteppingStonesScoreServiceImpl.java
+++ b/src/main/java/ku/user/domain/Ranking/service/SteppingStonesScoreServiceImpl.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,8 +27,8 @@ public class SteppingStonesScoreServiceImpl implements SteppingStonesScoreServic
     }
 
 
-    public List<SteppingStonesScore> findScoresByNickNameAndDate(String nickName, LocalDate date) {
-        return repository.findByNickNameAndCreatedAtDate(nickName, date);
+    public List<SteppingStonesScore> findScoresByNickNameAndDate(String nickName, LocalDateTime startDate, LocalDateTime endDate) {
+        return repository.findByNickNameAndCreatedAtBetween(nickName, startDate, endDate);
     }
 
     @Transactional

--- a/src/main/java/ku/user/domain/Ranking/service/SteppingStonesScoreServiceImpl.java
+++ b/src/main/java/ku/user/domain/Ranking/service/SteppingStonesScoreServiceImpl.java
@@ -1,0 +1,63 @@
+package ku.user.domain.Ranking.service;
+
+import ku.user.domain.Ranking.domain.Status;
+import ku.user.domain.Ranking.domain.SteppingStonesScore;
+import ku.user.domain.Ranking.infrastructure.SteppingScoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SteppingStonesScoreServiceImpl implements SteppingStonesScoreService{
+    private final SteppingScoreRepository repository;
+    @Transactional
+    public SteppingStonesScore saveScore(SteppingStonesScore steppingStonesScore) {
+        return repository.save(steppingStonesScore);
+    }
+
+
+    public List<SteppingStonesScore> findScoresByNickName(String nickName) {
+        List<SteppingStonesScore> scores = repository.findSteppingStonesScoresByNickName(nickName);
+        return scores;
+    }
+
+
+    public List<SteppingStonesScore> findScoresByNickNameAndDate(String nickName, LocalDate date) {
+        return repository.findByNickNameAndCreatedAtDate(nickName, date);
+    }
+
+    @Transactional
+    public void updateScoreStatus(String nickName) {
+        List<SteppingStonesScore> scores = repository.findSteppingStonesScoresByNickName(nickName);
+
+        if (scores.isEmpty()) {
+            throw new IllegalArgumentException("해당 닉네임의 기록은 존재하지 않음: " + nickName);
+        }
+
+        boolean hasActiveRecord = false;
+        for (SteppingStonesScore score : scores) {
+            if (score.getStatus() == Status.ACTIVE) {
+                score.setStatus(Status.INACTIVE);
+                hasActiveRecord = true;
+            }
+        }
+
+        if (!hasActiveRecord) {
+            System.out.println("이미 비활성화 되어 있는 캐릭터입니다.");
+            return;
+        }
+
+        repository.saveAll(scores);
+    }
+
+
+    public SteppingStonesScore findHighestScoreByNickName(String nickName) {
+        Optional<SteppingStonesScore> optionalScore = repository.findTopByNickNameOrderByScoreDesc(nickName);
+        return optionalScore.orElse(null);
+    }
+}


### PR DESCRIPTION
### ✏️ 작업 개요
sologame 기록 저장

### ⛳ 작업 분류
- [x] 저장 controller api 개발
- [x] 솔로 미니게임 각 레이어별 로직 추가
- [x] DTO 추가 및 validate 추가

### 🔨 작업 상세 내용
  1.  현재 저희 게임의 솔로 미니게임 2개에 대해서만 기록을 저장하게 구성하였습니다. 추후 멀티 미니게임의 논의가 끝나면 추가하도록 하겠습니다.
  2. controller의 경우 실질적으로 호출은 현재 저장 api만 필요하다고 판단이 되어 save만 추가해두었으며 서비스 레이어에 다른 도메인에서 해당 서비스 로직을 사용할 것 같아 몇개 만들어 두었습니다.

### 💡 생각해볼 문제
- 냉무
