### PR TITLE
Global exception 도입

### DIFF
--- a/src/main/java/ku/user/domain/character/exception/CharacterCreateException.java
+++ b/src/main/java/ku/user/domain/character/exception/CharacterCreateException.java
@@ -1,0 +1,13 @@
+package ku.user.domain.character.exception;
+
+import ku.user.global.exception.CustomException;
+import ku.user.global.exception.ErrorCode;
+import org.springframework.dao.DataAccessException;
+
+public class CharacterCreateException extends CustomException {
+
+    public CharacterCreateException() {
+        super("이미 캐릭터가 있거나 닉네임이 중복입니다.", ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+}

--- a/src/main/java/ku/user/domain/character/service/CharacterService.java
+++ b/src/main/java/ku/user/domain/character/service/CharacterService.java
@@ -2,9 +2,11 @@ package ku.user.domain.character.service;
 
 import ku.user.domain.character.dao.CharacterRepository;
 import ku.user.domain.character.domain.Character;
+import ku.user.domain.character.exception.CharacterCreateException;
 import ku.user.domain.user.infrastructure.entity.UserEntity;
 import ku.user.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,7 +21,11 @@ public class CharacterService {
 
     @Transactional
     public Character save(Character character) {
-        return characterRepository.save(character);
+        try {
+            return characterRepository.save(character);
+        } catch (DataAccessException e) {
+            throw new CharacterCreateException();
+        }
     }
 
     @Transactional

--- a/src/main/java/ku/user/global/exception/CustomException.java
+++ b/src/main/java/ku/user/global/exception/CustomException.java
@@ -1,0 +1,20 @@
+package ku.user.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/ku/user/global/exception/CustomException.java
+++ b/src/main/java/ku/user/global/exception/CustomException.java
@@ -3,7 +3,7 @@ package ku.user.global.exception;
 import lombok.Getter;
 
 @Getter
-public class CustomException extends RuntimeException {
+public abstract class CustomException extends RuntimeException {
 
     private final ErrorCode errorCode;
 

--- a/src/main/java/ku/user/global/exception/ErrorCode.java
+++ b/src/main/java/ku/user/global/exception/ErrorCode.java
@@ -1,0 +1,19 @@
+package ku.user.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+
+    //global
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"G500","서버 내부에서 에러가 발생하였습니다"),
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/ku/user/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ku/user/global/exception/GlobalExceptionHandler.java
@@ -12,13 +12,17 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(RuntimeException.class)
-    private ResponseEntity<?> handleRuntimeException(RuntimeException e) {
-        return responseException(ErrorCode.INTERNAL_SERVER_ERROR,e);
+    private ResponseEntity<?> handleRuntimeException(RuntimeException exception) {
+        return responseException(ErrorCode.INTERNAL_SERVER_ERROR,ErrorCode.INTERNAL_SERVER_ERROR.getMessage(),exception);
+    }
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<?> handleCustomException(CustomException exception) {
+        return responseException(exception.getErrorCode(),exception.getMessage(),exception);
     }
 
-    private ResponseEntity<?> responseException(ErrorCode errorCode, Exception e) {
+    private ResponseEntity<?> responseException(ErrorCode errorCode,String message, Exception e) {
         log.error("{}: {} : {}", errorCode, errorCode.getMessage(), e.getMessage());
-        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode,message);
         ApiResponse<?> apiResponse = ApiResponse.fromError(errorResponse);
         return ResponseEntity
                 .status(errorCode.getHttpStatus())

--- a/src/main/java/ku/user/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ku/user/global/exception/GlobalExceptionHandler.java
@@ -16,7 +16,7 @@ public class GlobalExceptionHandler {
         return responseException(ErrorCode.INTERNAL_SERVER_ERROR,ErrorCode.INTERNAL_SERVER_ERROR.getMessage(),exception);
     }
     @ExceptionHandler(CustomException.class)
-    protected ResponseEntity<?> handleCustomException(CustomException exception) {
+    private ResponseEntity<?> handleCustomException(CustomException exception) {
         return responseException(exception.getErrorCode(),exception.getMessage(),exception);
     }
 

--- a/src/main/java/ku/user/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ku/user/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package ku.user.global.exception;
+
+import ku.user.global.response.ApiResponse;
+import ku.user.global.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RuntimeException.class)
+    private ResponseEntity<?> handleRuntimeException(RuntimeException e) {
+        return responseException(ErrorCode.INTERNAL_SERVER_ERROR,e);
+    }
+
+    private ResponseEntity<?> responseException(ErrorCode errorCode, Exception e) {
+        log.error("{}: {} : {}", errorCode, errorCode.getMessage(), e.getMessage());
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+        ApiResponse<?> apiResponse = ApiResponse.fromError(errorResponse);
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(apiResponse);
+
+    }
+
+
+
+}

--- a/src/main/java/ku/user/global/response/ApiResponse.java
+++ b/src/main/java/ku/user/global/response/ApiResponse.java
@@ -26,4 +26,8 @@ public class ApiResponse<T>{
     public ErrorResponse getErrorResponse() {
         return errorResponse;
     }
+
+    public static <T> ApiResponse<T> fromError(ErrorResponse errorResponse) {
+        return new ApiResponse<>(false, null, errorResponse);
+    }
 }

--- a/src/main/java/ku/user/global/response/ErrorResponse.java
+++ b/src/main/java/ku/user/global/response/ErrorResponse.java
@@ -17,10 +17,10 @@ public class ErrorResponse {
                 .build();
     }
 
-    public static ErrorResponse of(ErrorCode errorCode) {
+    public static ErrorResponse of(ErrorCode errorCode,String message) {
         return ErrorResponse.builder()
                 .code(errorCode.getCode())
-                .message(errorCode.getMessage())
+                .message(message)
                 .build();
     }
 }

--- a/src/main/java/ku/user/global/response/ErrorResponse.java
+++ b/src/main/java/ku/user/global/response/ErrorResponse.java
@@ -1,12 +1,26 @@
 package ku.user.global.response;
 
+import ku.user.global.exception.ErrorCode;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class ErrorResponse {
+
+    private String code;
     private String message;
 
-    public ErrorResponse(String message) {
-        this.message = message;
+    public static ErrorResponse of(String message) {
+        return ErrorResponse.builder()
+                .message(message)
+                .build();
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .build();
     }
 }

--- a/src/main/java/ku/user/global/security/CustomLoginFailureHandler.java
+++ b/src/main/java/ku/user/global/security/CustomLoginFailureHandler.java
@@ -64,7 +64,7 @@ public class CustomLoginFailureHandler extends SimpleUrlAuthenticationFailureHan
         response.setContentType("application/json"); // 응답 형식 설정 (예: 텍스트)
 
         ObjectMapper objectMapper = new ObjectMapper();
-        ApiResponse<String> apiResponse = new ApiResponse<>(false, null, new ErrorResponse(errorMessage));
+        ApiResponse<String> apiResponse = new ApiResponse<>(false, null, ErrorResponse.of(errorMessage));
         Map<String, Object> errorMap = Collections.singletonMap("error", apiResponse);
         String jsonResponse = objectMapper.writeValueAsString(apiResponse);
         response.getWriter().write(jsonResponse); // 응답 본문에 에러 메시지 작성


### PR DESCRIPTION
### ✏️ 작업 개요
- #29 

### ⛳ 작업 분류
- [x] Exception handler 등록
- [x] Custom handler, ErrorCode 등록

### 🔨 작업 상세 내용
  1. Global exception 도입하였습니다. 
  2. exception을 사용하는 경우는 2가지 입니다.(ErrorCode에 exception을 등록해서 사용할 수 있고, CustomHandler를 상속하여 도메인별 구체적인 Exception을 등록하여 사용할 수 있습니다.)
  4. errorResponse의 code 를 추가하였습니다. G500 (더 구체적인 에러 코드 제시를 위해 도메인 +code로 하면 어떤가요? G는 Global)

### 💡 생각해볼 문제
- exception을 처리하는 방법은 크게 두가지가 있었습니다. 
- 첫번째는 ResponseEntity를 반환하는 방법과 ProblemDetail을 반환하는 방법이 있습니다.
- ProblemDetail을 반환하는 경우  error response data의 스펙이 변경되게 됩니다. 
![image](https://github.com/user-attachments/assets/e7777f17-f814-4d17-a3f3-666b245e6af9)
- 따라서 ResponseEntity을 반환하고 httpcode만 바꾸는 식으로 구현하게 되었습니다.
- **더 좋은 방법이 있으면 도입하겠습니다**
- 여담으로 http code를 직접 넣어봤는데 일부 code는 클라이언트 측에서 지원을 하지 않는지 postman에서 block되는 것을 확인
