### PR TITLE
퀘스트 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 	compileOnly 'org.projectlombok:lombok'
-	//runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
+	//runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/ku/user/domain/quest/controller/QuestController.java
+++ b/src/main/java/ku/user/domain/quest/controller/QuestController.java
@@ -1,0 +1,31 @@
+package ku.user.domain.quest.controller;
+
+import jakarta.ws.rs.PATCH;
+import ku.user.domain.quest.domain.Quest;
+import ku.user.domain.quest.dto.response.GetUserQuestsResponse;
+import ku.user.domain.quest.service.QuestService;
+import ku.user.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class QuestController {
+
+    private final QuestService questService;
+
+    @GetMapping("/quests")
+    public ApiResponse<GetUserQuestsResponse> checkQuest(@RequestParam String email){
+        Quest quest = questService.checkAndRefreshQuest(email);
+        GetUserQuestsResponse getUserQuestsResponse = GetUserQuestsResponse.toDto(quest);
+        return new ApiResponse<>(true, getUserQuestsResponse, null);
+    }
+
+
+
+
+
+}

--- a/src/main/java/ku/user/domain/quest/controller/QuestController.java
+++ b/src/main/java/ku/user/domain/quest/controller/QuestController.java
@@ -2,14 +2,13 @@ package ku.user.domain.quest.controller;
 
 import jakarta.ws.rs.PATCH;
 import ku.user.domain.quest.domain.Quest;
+import ku.user.domain.quest.dto.request.PostUserQuestRequest;
 import ku.user.domain.quest.dto.response.GetUserQuestsResponse;
+import ku.user.domain.quest.dto.response.PostUserQuestResponse;
 import ku.user.domain.quest.service.QuestService;
 import ku.user.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,14 +17,18 @@ public class QuestController {
     private final QuestService questService;
 
     @GetMapping("/quests")
-    public ApiResponse<GetUserQuestsResponse> checkQuest(@RequestParam String email){
+    public ApiResponse<GetUserQuestsResponse> checkQuest(@RequestParam String email) {
         Quest quest = questService.checkAndRefreshQuest(email);
         GetUserQuestsResponse getUserQuestsResponse = GetUserQuestsResponse.toDto(quest);
         return new ApiResponse<>(true, getUserQuestsResponse, null);
     }
 
-
-
+    @PostMapping("/quests")
+    public ApiResponse<PostUserQuestResponse> solveQuest(@RequestParam String email, @RequestBody PostUserQuestRequest postUserQuestRequest) {
+        Quest quest = questService.solveQuestByEmail(postUserQuestRequest.getQuestIndex(), email);
+        PostUserQuestResponse postUserQuestResponse = PostUserQuestResponse.toDto(quest);
+        return new ApiResponse<>(true, postUserQuestResponse, null);
+    }
 
 
 }

--- a/src/main/java/ku/user/domain/quest/dao/QuestRepository.java
+++ b/src/main/java/ku/user/domain/quest/dao/QuestRepository.java
@@ -5,13 +5,16 @@ import ku.user.domain.quest.domain.Quest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import javax.swing.text.html.Option;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface QuestRepository extends JpaRepository<Quest,Long> {
-    @Query("SELECT q.quest1 FROM Quest q WHERE q.userId = :userId AND q.createdAt = :createdAt")
-    Optional<Quest> findQuestByUserIdAndCompletionDate(@Param("userId") Long userId, @Param("createdAt") LocalDateTime createdAt);
+    @Query("SELECT q FROM Quest q WHERE q.userId = :userId AND q.createdAt = :createdAt")
+    Optional<Quest> findQuestByUserIdAndCompletionDate(@Param("userId") Long userId, @Param("createdAt") LocalDate createdAt);
 
+    Optional<Quest> findByUserId(Long userId);
     /*@Query("SELECT q FROM Quest q WHERE q.userId = :userId AND DATE(q.createdAt) = CURRENT_DATE")
     Optional<Quest> findQuestByUserIdAndToday(@Param("userId") Long userId);*/
 

--- a/src/main/java/ku/user/domain/quest/dao/QuestRepository.java
+++ b/src/main/java/ku/user/domain/quest/dao/QuestRepository.java
@@ -1,0 +1,18 @@
+package ku.user.domain.quest.dao;
+
+import feign.Param;
+import ku.user.domain.quest.domain.Quest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface QuestRepository extends JpaRepository<Quest,Long> {
+    @Query("SELECT q.quest1 FROM Quest q WHERE q.userId = :userId AND q.createdAt = :createdAt")
+    Optional<Quest> findQuestByUserIdAndCompletionDate(@Param("userId") Long userId, @Param("createdAt") LocalDateTime createdAt);
+
+    /*@Query("SELECT q FROM Quest q WHERE q.userId = :userId AND DATE(q.createdAt) = CURRENT_DATE")
+    Optional<Quest> findQuestByUserIdAndToday(@Param("userId") Long userId);*/
+
+}

--- a/src/main/java/ku/user/domain/quest/domain/Quest.java
+++ b/src/main/java/ku/user/domain/quest/domain/Quest.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.relational.core.sql.In;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -31,16 +32,24 @@ public class Quest {
     private Integer quest3;
     private LocalDateTime quest3CompletedAt;
 
-    @JsonFormat(pattern = "yyyy-MM-dd")
-    private LocalDateTime createdAt;
+    private LocalDate createdAt;
 
-    public static Quest from(Long userId, List<Integer> randomQuestNumber){
+    public static Quest from(Long userId, List<Integer> randomQuestNumber) {
         return Quest.builder()
                 .userId(userId)
                 .quest1(randomQuestNumber.get(0))
                 .quest2(randomQuestNumber.get(1))
                 .quest3(randomQuestNumber.get(2))
-                .createdAt(LocalDateTime.now())
+                .createdAt(LocalDate.now())
                 .build();
+    }
+
+    public void solve(Integer questIndex) {
+        if (quest1.equals(questIndex))
+            quest1CompletedAt = LocalDateTime.now();
+        if (quest2.equals(questIndex))
+            quest2CompletedAt = LocalDateTime.now();
+        if (quest3.equals(questIndex))
+            quest3CompletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/ku/user/domain/quest/domain/Quest.java
+++ b/src/main/java/ku/user/domain/quest/domain/Quest.java
@@ -1,20 +1,19 @@
 package ku.user.domain.quest.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.relational.core.sql.In;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
+@Getter
+@Table(name = "quests")
 public class Quest {
 
     @Id
@@ -23,12 +22,25 @@ public class Quest {
 
     private Long userId;
 
-    private boolean quest1;
+    private Integer quest1;
     private LocalDateTime quest1CompletedAt;
 
-    private boolean quest2;
+    private Integer quest2;
     private LocalDateTime quest2CompletedAt;
 
-    private boolean quest3;
+    private Integer quest3;
     private LocalDateTime quest3CompletedAt;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDateTime createdAt;
+
+    public static Quest from(Long userId, List<Integer> randomQuestNumber){
+        return Quest.builder()
+                .userId(userId)
+                .quest1(randomQuestNumber.get(0))
+                .quest2(randomQuestNumber.get(1))
+                .quest3(randomQuestNumber.get(2))
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/src/main/java/ku/user/domain/quest/domain/Quest.java
+++ b/src/main/java/ku/user/domain/quest/domain/Quest.java
@@ -1,0 +1,34 @@
+package ku.user.domain.quest.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Quest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private boolean quest1;
+    private LocalDateTime quest1CompletedAt;
+
+    private boolean quest2;
+    private LocalDateTime quest2CompletedAt;
+
+    private boolean quest3;
+    private LocalDateTime quest3CompletedAt;
+}

--- a/src/main/java/ku/user/domain/quest/dto/request/PostUserQuestRequest.java
+++ b/src/main/java/ku/user/domain/quest/dto/request/PostUserQuestRequest.java
@@ -1,0 +1,11 @@
+package ku.user.domain.quest.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class PostUserQuestRequest {
+
+    private Integer questIndex;
+}

--- a/src/main/java/ku/user/domain/quest/dto/response/GetUserQuestsResponse.java
+++ b/src/main/java/ku/user/domain/quest/dto/response/GetUserQuestsResponse.java
@@ -1,0 +1,27 @@
+package ku.user.domain.quest.dto.response;
+
+import ku.user.domain.quest.domain.Quest;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Builder
+public record GetUserQuestsResponse (int firstQuestIndex,
+                                     int secondQuestIndex,
+                                     int thirdQuestIndex,
+                                     Boolean firstQuestClear,
+                                     Boolean secondQuestClear,
+                                     Boolean thirdQuestClear){
+
+    public static GetUserQuestsResponse toDto(Quest quest){
+        return GetUserQuestsResponse.builder()
+                .firstQuestIndex(quest.getQuest1())
+                .secondQuestIndex(quest.getQuest2())
+                .thirdQuestIndex(quest.getQuest3())
+                .firstQuestClear(quest.getQuest1CompletedAt() != null)
+                .secondQuestClear(quest.getQuest2CompletedAt() != null)
+                .thirdQuestClear(quest.getQuest3CompletedAt() != null)
+                .build();
+    }
+}

--- a/src/main/java/ku/user/domain/quest/dto/response/PostUserQuestResponse.java
+++ b/src/main/java/ku/user/domain/quest/dto/response/PostUserQuestResponse.java
@@ -1,0 +1,23 @@
+package ku.user.domain.quest.dto.response;
+
+import ku.user.domain.quest.domain.Quest;
+import lombok.Builder;
+
+@Builder
+public record PostUserQuestResponse(int firstQuestIndex,
+                                    int secondQuestIndex,
+                                    int thirdQuestIndex,
+                                    Boolean firstQuestClear,
+                                    Boolean secondQuestClear,
+                                    Boolean thirdQuestClear) {
+    public static PostUserQuestResponse toDto(Quest quest){
+        return PostUserQuestResponse.builder()
+                .firstQuestIndex(quest.getQuest1())
+                .secondQuestIndex(quest.getQuest2())
+                .thirdQuestIndex(quest.getQuest3())
+                .firstQuestClear(quest.getQuest1CompletedAt() != null)
+                .secondQuestClear(quest.getQuest2CompletedAt() != null)
+                .thirdQuestClear(quest.getQuest3CompletedAt() != null)
+                .build();
+    }
+}

--- a/src/main/java/ku/user/domain/quest/service/QuestService.java
+++ b/src/main/java/ku/user/domain/quest/service/QuestService.java
@@ -1,0 +1,52 @@
+package ku.user.domain.quest.service;
+
+import ku.user.domain.quest.dao.QuestRepository;
+import ku.user.domain.quest.domain.Quest;
+import ku.user.domain.quest.util.QuestUtil;
+import ku.user.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class QuestService {
+
+    private final QuestRepository questRepository;
+    private final UserService userService;
+
+    @Transactional
+    public Quest save(Quest quest){
+        return questRepository.save(quest);
+    }
+
+    /**
+     * 유저의 퀘스트를 조회한다.(가능하면 갱신한다)
+     *
+     * @param email
+     * @return quest
+     */
+    @Transactional
+    public Quest checkAndRefreshQuest(String email) {
+        Long userId = userService.getByEmail(email).getId();
+        LocalDateTime localDateTime = LocalDateTime.now();
+        Optional<Quest> questOptional = questRepository.findQuestByUserIdAndCompletionDate(userId, localDateTime);
+        return questOptional.orElseGet(() -> createDailyQuest(userId));
+    }
+
+    /**
+     * 새로운 퀘스트를 생성한다
+     * @param userId
+     * @return quest
+     */
+    @Transactional
+    public Quest createDailyQuest(Long userId) {
+        List<Integer> randomQuestNumber = QuestUtil.getRandomQuests(3);
+        Quest quest = Quest.from(userId, randomQuestNumber);
+        return save(quest);
+    }
+}

--- a/src/main/java/ku/user/domain/quest/util/QuestUtil.java
+++ b/src/main/java/ku/user/domain/quest/util/QuestUtil.java
@@ -1,0 +1,28 @@
+package ku.user.domain.quest.util;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class QuestUtil {
+
+    private QuestUtil() {
+    }
+
+    public static int QUEST_COUNT = 3;
+    private static final ThreadLocalRandom random = ThreadLocalRandom.current();
+
+    public static Integer getRandomQuest() {
+        return random.nextInt(QUEST_COUNT);
+    }
+
+    public static List<Integer> getRandomQuests(int count) {
+        Set<Integer> set = new HashSet<>();
+        while(set.size()<count){
+            Integer randomQuest = getRandomQuest() + 1;
+            set.add(randomQuest);
+        }
+        return set.stream().toList();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,30 +12,18 @@ spring:
     name: user-service
 
   datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${DB_HOST}:3306/kutaverse
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
-
-#    driver-class-name: org.h2.Driver
-#    url: jdbc:h2:mem:test  # 로컬에서 H2 메모리 DB 사용
-#    username: sa
-#    password:
-
-  h2:
-    console:
-      enabled: true
-      settings:
-        web-allow-others: true
-      path: /h2-console
 
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
+    database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
       ddl-auto: update        # DB 초기화 전략
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: true
         show_sql: true
         generate-ddl: true


### PR DESCRIPTION
### ✏️ 작업 개요
- #37 
- #28

### ⛳ 작업 분류
- [x] 퀘스트 API 추가
- [ ] 테스트 작성

### 🔨 작업 상세 내용
  1. 퀘스트 API 2개를 개발하였습니다.
  2. test 환경은 h2의존성을 유지했습니다 (CI 때문에)

### 💡 생각해볼 문제
- LocalDataTime은 분초 모두 저장한다는 점에서 query에 옵션을 추가해야합니다. 일일 퀘스트 갱신을 위한 created_at 필드를 LocalTime으로 변경하였습니다.
- POST /quests에 body에 email을 넣을 수 있었지만 최종적으로 jwt가 되야한다는 관점에서 body와 분리하여 QueryParameter로 변경하였습니다.
